### PR TITLE
Docs: add ERA5 precipitation data citation to README and About tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,11 @@ For visualization purposes (e.g., line charts, plots), these categories are trea
 
 This numerical averaging is a simplification and may not reflect a statistically sound interpretation of categorical data. However, it helps us visualize general precipitation trends across time and parks in a consistent way.
 
+### Gridded Climate Data Source
 
+The precipitation type raster data used for the heatmap is based on:
+
+> **ERA5 monthly averaged reanalysis data on single levels (2005–2025)**  
+> Variable: **Precipitation type**  
+> Format: **NetCDF**  
+> Source: [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means)

--- a/app_project.R
+++ b/app_project.R
@@ -85,10 +85,22 @@ ui <- fluidPage(
                            p("Use the sidebar to select a national park and time range, then explore the various tabs for visual insights."),
                            h4("Data Sources"),
                            tags$ul(
-                             tags$li(strong("Precipitation Types:"), " Derived from JSON-formatted park-specific records prepared for the course."),
-                             tags$li(strong("Gridded Climate Data:"), " NetCDF dataset provided in the course materials, specifically ", 
-                                     code("data/data_stepType-avg.nc"), ". It represents spatial precipitation averages over time."),
-                             tags$li(strong("Park Locations & Boundaries:"), " Custom GeoJSON files created or curated for the Serbian national park regions.")
+                             tags$li(
+                               strong("Precipitation Types:"),
+                               " Derived from JSON-formatted park-specific records prepared for the course."
+                             ),
+                             tags$li(
+                               strong("Gridded Climate Data:"),
+                               " ERA5 monthly averaged reanalysis data on single levels (2005–2025), variable: precipitation type. ",
+                               "Downloaded from the Copernicus Climate Data Store: ",
+                               a("https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means",
+                                 href = "https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means", target = "_blank"),
+                               ". Format: NetCDF."
+                             ),
+                             tags$li(
+                               strong("Park Locations & Boundaries:"),
+                               " Custom GeoJSON files created or curated for the Serbian national park regions."
+                             )
                            ),
                            
                            h4("Precipitation Type Categories"),


### PR DESCRIPTION
This PR adds a proper data source citation for the ERA5 monthly averaged precipitation type dataset.
The reference was added to both the README.md and the About tab inside the Shiny app.

